### PR TITLE
Update PowerMeterPanel to guard against wrong wavelength indexing

### DIFF
--- a/src/main/java/de/embl/rieslab/htsmlm/PowerMeterPanel.java
+++ b/src/main/java/de/embl/rieslab/htsmlm/PowerMeterPanel.java
@@ -77,7 +77,7 @@ public class PowerMeterPanel extends ConfigurablePanel{
 		comboBox_ = new JComboBox<String>(temp);
 		comboBox_.addActionListener (new ActionListener () {
 		    public void actionPerformed(ActionEvent e) {
-	    		temp_index = comboBox_.getSelectedIndex();
+	    		int temp_index = comboBox_.getSelectedIndex();
 			if(temp_index != -1){
 				selectedWavelength_ = temp_index;
 			}

--- a/src/main/java/de/embl/rieslab/htsmlm/PowerMeterPanel.java
+++ b/src/main/java/de/embl/rieslab/htsmlm/PowerMeterPanel.java
@@ -77,7 +77,10 @@ public class PowerMeterPanel extends ConfigurablePanel{
 		comboBox_ = new JComboBox<String>(temp);
 		comboBox_.addActionListener (new ActionListener () {
 		    public void actionPerformed(ActionEvent e) {
-	    		selectedWavelength_ = comboBox_.getSelectedIndex();
+	    		temp_index = comboBox_.getSelectedIndex();
+			if(temp_index != -1){
+				selectedWavelength_ = temp_index;
+			}
 		    }
 		});
 		toggleButton_ = new JToggleButton("Monitor");
@@ -295,13 +298,13 @@ public class PowerMeterPanel extends ConfigurablePanel{
 		int index = getCurrentWavelength();				
 		
 		double slope, offset;
-		if(index < slopes.size()) {
+		if(index >= 0 && index < slopes.size()) {
 			slope = slopes.get(index);
 		} else {
 			slope = 1.;
 		}
 
-		if(index < offsets.size()) {
+		if(index >= 0 && index < offsets.size()) {
 			offset = offsets.get(index);
 		} else {
 			offset = 0.;

--- a/src/main/java/de/embl/rieslab/htsmlm/PowerMeterPanel.java
+++ b/src/main/java/de/embl/rieslab/htsmlm/PowerMeterPanel.java
@@ -192,10 +192,6 @@ public class PowerMeterPanel extends ConfigurablePanel{
 				DefaultComboBoxModel<String> model = new DefaultComboBoxModel<String>(vals);
 				comboBox_.removeAllItems();
 				comboBox_.setModel(model);
-
-				if(vals.length > 0){
-					comboBox_.setSelectedIndex(0);
-				}
 			} catch (UnknownUIParameterException e) {
 				e.printStackTrace();
 			}

--- a/src/main/java/de/embl/rieslab/htsmlm/PowerMeterPanel.java
+++ b/src/main/java/de/embl/rieslab/htsmlm/PowerMeterPanel.java
@@ -192,6 +192,10 @@ public class PowerMeterPanel extends ConfigurablePanel{
 				DefaultComboBoxModel<String> model = new DefaultComboBoxModel<String>(vals);
 				comboBox_.removeAllItems();
 				comboBox_.setModel(model);
+
+				if(vals.length > 0){
+					comboBox_.setSelectedIndex(0);
+				}
 			} catch (UnknownUIParameterException e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
Somehow, `selectedWavelength_` can become equal to `-1` causing an out of index error when retrieving the slopes in the conversion.

This PR adds guards against storing `-1` and calling out of index values and ensure an item is selected when updating the combobox model.